### PR TITLE
Add linting configurations for html and css through prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,31 @@
+{
+    "semi": false,
+    "tabWidth": 2,
+    "useTabs": false,
+    "printWidth": 80,
+    "bracketSpacing": false,
+    "bracketSameLine": false,
+    "overrides": [
+        {
+            "files": "*.html",
+            "options": {
+                "tabWidth": 2,
+                "singleQuote": false
+            }
+        },
+        {
+            "files": "*.js",
+            "options": {
+                "semi": true,
+                "singleQuote": true
+            }
+        },
+        {
+            "files": "*.css",
+            "options": {
+                "semi": true,
+                "singleQuote": false
+            }
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "eslint-config-google": "^0.14.0",
         "jest": "^29.7.0",
         "jsdoc": "^4.0.4",
+        "prettier": "^3.4.1",
         "puppeteer": "^23.9.0"
       }
     },
@@ -4396,6 +4397,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.1.tgz",
+      "integrity": "sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "test": "jest",
     "lint": "npx eslint --config ./pipeline/.eslintrc.yml ./source/js",
     "lint-fix": "npx eslint --config ./pipeline/.eslintrc.yml ./source/js --fix",
-    "prettier": "npx prettier --check ./source/html/**/*.html",
-    "prettier-fix": "npx prettier --write ./source/html/**/*.html"
+    "prettier": "npx prettier --check ./source/html/**/*.html ./source/css/**/*.css",
+    "prettier-fix": "npx prettier --write ./source/html/**/*.html ./source/css/**/*.css"
   },
   "devDependencies": {
     "eslint": "^8.28.0",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,16 @@
   "scripts": {
     "test": "jest",
     "lint": "npx eslint --config ./pipeline/.eslintrc.yml ./source/js",
-    "lint-fix": "npx eslint --config ./pipeline/.eslintrc.yml ./source/js --fix"
+    "lint-fix": "npx eslint --config ./pipeline/.eslintrc.yml ./source/js --fix",
+    "prettier": "npx prettier --check ./source/html/**/*.html",
+    "prettier-fix": "npx prettier --write ./source/html/**/*.html"
   },
   "devDependencies": {
     "eslint": "^8.28.0",
     "eslint-config-google": "^0.14.0",
     "jest": "^29.7.0",
     "jsdoc": "^4.0.4",
+    "prettier": "^3.4.1",
     "puppeteer": "^23.9.0"
   }
 }

--- a/source/css/create.css
+++ b/source/css/create.css
@@ -1,36 +1,36 @@
 body {
-    font-family:  'Courier New', Courier, monospace;
-    margin: 20px;
-  }
-
-  #title{
-    text-align: center;
-    font-weight: bold;
-    font-size:30px;
+  font-family: "Courier New", Courier, monospace;
+  margin: 20px;
 }
 
-  #cancel-button {
-    font-family: 'Courier New', Courier, monospace;
-    display: block;
-    padding: 10px 20px;
-    background-color: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    float: left;
+#title {
+  text-align: center;
+  font-weight: bold;
+  font-size: 30px;
 }
 
-  #save-button {
-    font-family: 'Courier New', Courier, monospace;
-    display: block;
-    padding: 10px 20px;
-    background-color: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    float: right;
+#cancel-button {
+  font-family: "Courier New", Courier, monospace;
+  display: block;
+  padding: 10px 20px;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  float: left;
+}
+
+#save-button {
+  font-family: "Courier New", Courier, monospace;
+  display: block;
+  padding: 10px 20px;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  float: right;
 }
 
 #title-container {
@@ -39,12 +39,12 @@ body {
   align-items: center;
 
   flex-direction: row;
-  margin-top: 50px; 
+  margin-top: 50px;
 }
 
 #title-container label {
-  font-weight: bold; 
-  margin-right: 10px; 
+  font-weight: bold;
+  margin-right: 10px;
 }
 
 #title-container input[type="text"] {
@@ -54,8 +54,8 @@ body {
   border: 1px solid #ccc;
   border-radius: 5px;
   outline: none;
-  font-family: 'Courier New', Courier, monospace;
-  margin-bottom: 10px; 
+  font-family: "Courier New", Courier, monospace;
+  margin-bottom: 10px;
 }
 
 #title-container button {
@@ -70,24 +70,24 @@ body {
 
 #code-container,
 #comment-container {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 #code-container label,
 #comment-container label {
-    display: block;
-    font-weight: bold;
-    margin-bottom: 10px;
+  display: block;
+  font-weight: bold;
+  margin-bottom: 10px;
 }
 
 textarea {
-    width: 100%;
-    height: 150px; 
-    padding: 10px;
-    font-family: 'Courier New', Courier, monospace;
-    font-size: 16px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    resize: vertical; 
-    outline: none;
+  width: 100%;
+  height: 150px;
+  padding: 10px;
+  font-family: "Courier New", Courier, monospace;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  resize: vertical;
+  outline: none;
 }

--- a/source/css/home.css
+++ b/source/css/home.css
@@ -1,90 +1,89 @@
 body {
-    /* font-family: "Times New Roman", Times, serif; */
-    font-family:  'Courier New', Courier, monospace;
-    margin: 20px;
-  }
-  
-  #list-container {
-    max-width: 600px;
-    margin: auto;
-  }
+  /* font-family: "Times New Roman", Times, serif; */
+  font-family: "Courier New", Courier, monospace;
+  margin: 20px;
+}
 
-  #title{
-    text-align: center;
-    font-weight: bold;
-    font-size: 30px;
-  }
-  
-  .header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-  }
-  
-  .search-bar-container {
-    position: relative;
-    width: 30%;
-  }
-  
-  .search-bar-container .search-icon {
-    position: absolute;
-    left: 10px;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 18px;
-    color: #aaa;
-  }
-  
-  .search-bar-container input {
-    font-family:  'Courier New', Courier, monospace;
-    width: 100%;
-    padding: 20px 20px 20px 35px; /* Add padding-left for the icon */
-    font-size: 16px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    outline: none;
-  }
-  
-  .search-bar-container input:focus {
-    border-color: #28a745;
-  }
-  
-  .header button {
-    padding: 20px;
-    font-size: 16px;
-    font-family:  'Courier New', Courier, monospace;
-    background-color: #28a745;
-    color: white;
-    border: none;
-    cursor: pointer;
-    border-radius: 5px;
-  }
-  
-  .header button:hover {
-    background-color: #218838;
-  }
-  
-  .notes-list {
-    list-style: none;
-    padding:0;
-    max-height: 80vh;
-    overflow-y: auto;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-  }
-  
-  .notes-list li {
-    padding: 20px;
-    border-bottom: 1px solid #ddd;
-    cursor: pointer;
-  }
-  
-  .notes-list li:hover {
-    background-color: #f8f9fa;
-  }
-  
-  .notes-list li:last-child {
-    border-bottom: none;
-  }
-  
+#list-container {
+  max-width: 600px;
+  margin: auto;
+}
+
+#title {
+  text-align: center;
+  font-weight: bold;
+  font-size: 30px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.search-bar-container {
+  position: relative;
+  width: 30%;
+}
+
+.search-bar-container .search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 18px;
+  color: #aaa;
+}
+
+.search-bar-container input {
+  font-family: "Courier New", Courier, monospace;
+  width: 100%;
+  padding: 20px 20px 20px 35px; /* Add padding-left for the icon */
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  outline: none;
+}
+
+.search-bar-container input:focus {
+  border-color: #28a745;
+}
+
+.header button {
+  padding: 20px;
+  font-size: 16px;
+  font-family: "Courier New", Courier, monospace;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  cursor: pointer;
+  border-radius: 5px;
+}
+
+.header button:hover {
+  background-color: #218838;
+}
+
+.notes-list {
+  list-style: none;
+  padding: 0;
+  max-height: 80vh;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+}
+
+.notes-list li {
+  padding: 20px;
+  border-bottom: 1px solid #ddd;
+  cursor: pointer;
+}
+
+.notes-list li:hover {
+  background-color: #f8f9fa;
+}
+
+.notes-list li:last-child {
+  border-bottom: none;
+}

--- a/source/css/view.css
+++ b/source/css/view.css
@@ -1,87 +1,87 @@
 body {
-    font-family: 'Courier New', Courier, monospace;
-    margin: 20px;
-    padding: 0;
-    background-color: #f9f9f9;
-    color: #333;
+  font-family: "Courier New", Courier, monospace;
+  margin: 20px;
+  padding: 0;
+  background-color: #f9f9f9;
+  color: #333;
 }
 
 h1 {
-    text-align: center;
+  text-align: center;
 }
 
 #button-container {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 20px; 
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
 }
 
 #title-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    justify-content: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
 }
 
 #code-container {
-    list-style: none;
-    max-height: 40vh;
-    overflow-y: auto;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    justify-content: center;
-    border: 2px solid #ccc; 
-    padding: 20px;         
-    border-radius: 10px;   
-    background-color: #f9f9f9; 
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); 
+  list-style: none;
+  max-height: 40vh;
+  overflow-y: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
+  border: 2px solid #ccc;
+  padding: 20px;
+  border-radius: 10px;
+  background-color: #f9f9f9;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
-#code-comment-container{
-    padding:20px;
-    list-style: none;
-    padding:0;
-    max-height: 80vh;
-    overflow-y: auto;
+#code-comment-container {
+  padding: 20px;
+  list-style: none;
+  padding: 0;
+  max-height: 80vh;
+  overflow-y: auto;
 }
 #comment-container {
-    list-style: none;
-    max-height: 40vh;
-    overflow-y: auto;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
-    justify-content: center;
+  list-style: none;
+  max-height: 40vh;
+  overflow-y: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  justify-content: center;
 }
 
 #home-button {
-    font-family: 'Courier New', Courier, monospace;
-    display: block;
-    padding: 10px 20px;
-    background-color: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    float: left;
+  font-family: "Courier New", Courier, monospace;
+  display: block;
+  padding: 10px 20px;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  float: left;
 }
 
 #home-button:hover {
-    background-color: #0056b3;
+  background-color: #0056b3;
 }
 
 #edit-button {
-    font-family: 'Courier New', Courier, monospace;
-    display: block;
-    padding: 10px 20px;
-    background-color: #28a745;
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    float: right;
+  font-family: "Courier New", Courier, monospace;
+  display: block;
+  padding: 10px 20px;
+  background-color: #28a745;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+  float: right;
 }
 
 #edit-button:hover {
-    background-color: #0056b3;
+  background-color: #0056b3;
 }

--- a/source/html/create.html
+++ b/source/html/create.html
@@ -1,41 +1,48 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notes App</title>
+    <link rel="stylesheet" href="../css/create.css" />
+  </head>
 
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Notes App</title>
-        <link rel="stylesheet" href="../css/create.css">
-      </head>
+  <div id="button-container">
+    <button id="cancel-button" onclick="goHome()">Cancel</button>
+    <button id="save-button" onclick="saveAndReturn()">Save and Return</button>
+  </div>
 
-    <div id="button-container">
-      <button id="cancel-button" onclick="goHome()">Cancel</button>
-      <button id="save-button" onclick="saveAndReturn()">Save and Return</button>
-    </div>  
-    
-    <body>
+  <body>
+    <div id="title">Code Snippet Saver</div>
 
-      <div id="title">
-        Code Snippet Saver
-      </div>
+    <div id="title-container">
+      <label for="text-input">New Note Title:</label>
+      <input
+        type="text"
+        id="text-input"
+        name="text-input"
+        placeholder="Enter title here..."
+      />
+    </div>
 
-      <div id="title-container">
-        <label for="text-input">New Note Title:</label>
-        <input type="text" id="text-input" name="text-input" placeholder="Enter title here...">
-      </div>
+    <div id="code-container">
+      <label for="code-input">Code:</label>
+      <textarea
+        id="code-input"
+        placeholder="Write your code here..."
+      ></textarea>
+    </div>
 
-      <div id="code-container">
-        <label for="code-input">Code:</label>
-        <textarea id="code-input" placeholder="Write your code here..."></textarea>
-      </div>
+    <div id="comment-container">
+      <label for="comment-input">Comments:</label>
+      <textarea
+        id="comment-input"
+        placeholder="Write your comments here..."
+      ></textarea>
+    </div>
 
-      <div id="comment-container">
-        <label for="comment-input">Comments:</label>
-        <textarea id="comment-input" placeholder="Write your comments here..."></textarea>
-      </div>
-      
-      <script src="../js/create.js"></script>
-      <script src="../js/data.js"></script>
-    </body>
+    <script src="../js/create.js"></script>
+    <script src="../js/data.js"></script>
+  </body>
 </html>

--- a/source/html/home.html
+++ b/source/html/home.html
@@ -1,35 +1,34 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Notes App</title>
-  <link rel="stylesheet" href="../css/home.css">
-</head>
-<body>
-  <div id="app">
-    <div class="header">
-      <div class="search-bar-container">
-        <i class="search-icon">&#128269</i>
-        <input type="text" id="search-bar" placeholder="Search notes by title." oninput="filterNotes()">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notes App</title>
+    <link rel="stylesheet" href="../css/home.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div class="header">
+        <div class="search-bar-container">
+          <i class="search-icon">&#128269;</i>
+          <input
+            type="text"
+            id="search-bar"
+            placeholder="Search notes by title."
+            oninput="filterNotes()"
+          />
+        </div>
+        <button onclick="createNewNote()">+ New Note</button>
       </div>
-      <button onclick="createNewNote()">+ New Note</button>
+
+      <div id="title">Code Snippet Saver</div>
+
+      <div id="list-container">
+        <ul id="notes-list" class="notes-list"></ul>
+      </div>
     </div>
-
-    <div id="title">
-      Code Snippet Saver
-    </div>
-
-
-    <div id="list-container">
-      <ul id="notes-list" class="notes-list">    </ul>
-    </div>
-  
-
-  </div>
-  <script src="../js/data.js"></script>
-  <script src="../js/home.js"></script>
-
-</body>
+    <script src="../js/data.js"></script>
+    <script src="../js/home.js"></script>
+  </body>
 </html>

--- a/source/html/view.html
+++ b/source/html/view.html
@@ -1,35 +1,32 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notes App</title>
+    <link rel="stylesheet" href="../css/view.css" />
+  </head>
 
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Notes App</title>
-        <link rel="stylesheet" href="../css/view.css">
-      </head>
-      
-      <div id="button-container">
-        <button id="home-button" onclick="goBackHome()">Home</button>
-        <button id="edit-button" onclick="editNote()">Edit Note</button>
-    </div>
+  <div id="button-container">
+    <button id="home-button" onclick="goBackHome()">Home</button>
+    <button id="edit-button" onclick="editNote()">Edit Note</button>
+  </div>
 
-    <body>
+  <body>
     <div id="title-container">
-        <!-- Title will be dynamically inserted here -->
+      <!-- Title will be dynamically inserted here -->
     </div>
     <div id="code-comment-container">
-        <div id="code-container">
-            <!-- Code will be dynamically inserted here -->
-        </div>
-        <h4>
-            Comment
-        </h4>
-        <div id="comment-container">
-            <!-- Comment will be dynamically inserted here -->
-        </div>
+      <div id="code-container">
+        <!-- Code will be dynamically inserted here -->
+      </div>
+      <h4>Comment</h4>
+      <div id="comment-container">
+        <!-- Comment will be dynamically inserted here -->
+      </div>
     </div>
 
     <script src="../js/data.js"></script>
     <script src="../js/view.js"></script>
-    </body>
+  </body>
 </html>


### PR DESCRIPTION
- Added prettier dependency to lint html and css
- `npm run prettier` locally to see which files have styling errors/warnings
- `npm run prettier-fix` to automatically fix them
- `npx prettier "./source/html/home.html" | diff -u ./source/html/home.html -` to see what prettier would change on the particular file (so swap path to see the file that's giving you error.
- fixed existing styling inconsistencies in html and css. 

 
